### PR TITLE
Fix gnome-keyring-daemon: Operation not permitted

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,24 +21,3 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # [Optional] Uncomment this line to install global node packages.
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g @zowe/cli@zowe-v2-lts && zowe plugins install @zowe/cics-for-zowe-cli@zowe-v2-lts 2>&1" ; fi
-
-# TODO 
-# https://docs.zowe.org/stable/user-guide/cli-configure-scs-on-headless-linux-os
-
-# TBC interactive commands to unlock the Gnome keyring?
-# export $(dbus-launch)
-# printf '\n' | gnome-keyring-daemon -r --unlock --components=secrets
-
-# Fails with...
-# bash: /usr/bin/gnome-keyring-daemon: Operation not permitted
-
-# TBC automatically unlock the Gnome keyring at log on?
-
-# Is this required/correct?
-# RUN echo "auth optional pam_gnome_keyring.so" >> /etc/pam.d/login \
-#     && echo "session optional pam_gnome_keyring.so auto_start" >> /etc/pam.d/sshd
-
-# Update ~/.bashrc?
-# if test -z "$DBUS_SESSION_BUS_ADDRESS" ; then
-#   exec dbus-run-session -- $SHELL
-# fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,12 @@
 		"JAVA_HOME": "/usr/lib/jvm/msopenjdk-current"
 	},
 
+	// IPC_LOCK is required to run gnome-keyring-daemon. See:
+	// https://stackoverflow.com/questions/75672304/why-does-gnome-keyring-daemon-fail-with-operation-not-permitted-in-a-dev-conta
+	"capAdd": [
+		"IPC_LOCK"
+	],
+
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "java -version",
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Experimental project to try out modern development techniques with CICS
 
 The journey so far...
 
-## dev container
+## Dev Container
 
 Attempting to create a dev container suitable for the [IBM Z Open Editor](https://ibm.github.io/zopeneditor-about/Docs/getting_started.html#installing-the-ibm-z-open-editor-vs-code-extension)
+
+Run the following to unlock the Gnome keyring manually to run Zowe CLI commands.
+
+```shell
+export $(dbus-launch)
+printf '\n' | gnome-keyring-daemon -r --unlock --components=secrets
+```
+
+**TODO:** update the dev container to [unlock the Gnome keyring automatically](https://docs.zowe.org/stable/user-guide/cli-configure-scs-on-headless-linux-os/#unlocking-the-keyring-automatically).


### PR DESCRIPTION
gnome-keyring-daemon requires the IPC_LOCK capability